### PR TITLE
[feature][backward incompatible] support arbitrary config

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,57 @@
+<!---
+if you do not know how to fill, you may leave some of questions below empty. We
+will ask further questions. see the procedure at:
+https://github.com/reallyenglish/ansible-role-example/tree/master/docs/Procedures/Creating_Issue
+-->
+
+##### ISSUE TYPE
+<!--- Pick one below and delete the rest: -->
+ - Bug Report
+ - Feature Idea
+ - Documentation Report
+
+##### ROLE VERSION
+<!--- Mention the role version -->
+```
+
+```
+
+##### CONFIGURATION
+<!---
+Mention any settings you have changed/added/removed in ansible.cfg
+(or using the ANSIBLE_* environment variables).
+-->
+
+##### OS / ENVIRONMENT
+<!---
+Mention the OS, its version to which the role is applied, the OS and the
+version you are running Ansible from, or say `N/A` for anything that is not
+platform-specific.
+-->
+
+##### SUMMARY
+<!--- Explain the problem briefly -->
+
+##### STEPS TO REPRODUCE
+<!---
+For bugs, show exactly how to reproduce the problem, optionally using a minimal
+test-case.  For new features, show how the feature would be used.
+-->
+
+<!--- Paste example playbooks or commands between quotes below -->
+<!--- You can also paste gist.github.com links for larger files -->
+```yaml
+
+```
+
+<!--- Paste any logs you have -->
+
+
+```
+```
+
+##### EXPECTED RESULTS
+<!--- What did you expect to happen when running the steps above? -->
+
+##### ACTUAL RESULTS
+<!--- What actually happened? -->

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -47,9 +47,25 @@ platforms:
       extra_vars:
         ansible_python_interpreter: '/usr/local/bin/python'
 
+  - name: openbsd-6.1-amd64
+    driver:
+      box: trombik/ansible-openbsd-6.1-amd64
+      box_check_update: false
+    driver_config:
+      ssh:
+        shell: '/bin/sh'
+    provisioner:
+      extra_vars:
+        ansible_python_interpreter: '/usr/local/bin/python'
+
   - name: ubuntu-14.04-amd64
     driver:
       box: trombik/ansible-ubuntu-14.04-amd64
+      box_check_update: false
+
+  - name: ubuntu-16.04-amd64
+    driver:
+      box: trombik/ansible-ubuntu-16.04-amd64
       box_check_update: false
 
   - name: centos-7.3-x86_64

--- a/README.md
+++ b/README.md
@@ -234,8 +234,7 @@ None
               - 192.168.133.101 my_tsig_key
               - 127.0.0.1 NOKEY
           - name: allow-notify
-            values:
-              - 192.168.0.111 NOKEY
+            value: 192.168.0.111 NOKEY
           - name: request-xfr
             values:
               - 192.168.0.111 NOKEY

--- a/README.md
+++ b/README.md
@@ -19,85 +19,163 @@ it, other platforms do not require it.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| nsd\_user | nsd user | \_\_nsd\_user |
-| nsd\_group | nsd group | \_\_nsd\_group |
-| nsd\_db\_dir | db dir | {{ \_\_nsd\_db\_dir }} |
-| nsd\_run\_dir | run dir | \_\_nsd\_run\_dir |
-| nsd\_state\_dir | state dir | \_\_nsd\_state\_dir |
-| nsd\_service | service name | nsd |
-| nsd\_conf\_dir | path to config dir | {{ \_\_nsd\_conf\_dir }} |
-| nsd\_conf | path to nsd.conf | {{ nsd\_conf\_dir }}/nsd.conf |
-| nsd\_flags | (not used yet) | "" |
-| nsd\_chroot\_enable | enable chroot | false |
-| nsd\_chroot\_dir | dir to chroot | {{ nsd\_conf\_dir }} |
-| nsd\_statistics\_enable | enable statistics | false |
-| nsd\_ip\_addresses | a list of ip address to listen on | all available ip addresses |
-| nsd\_listen\_on\_localhost | listen on localhost | true |
-| nsd\_conf\_do\_ip4 | enable ip4 | yes |
-| nsd\_conf\_do\_ip6 | enable ip6 | no |
-| nsd\_conf\_verbosity | verbosesity | 0 |
-| nsd\_conf\_zonesdir | zone dir | {{ nsd\_conf\_dir }} |
-| nsd\_conf\_statistics | interval to update stats if nsd\_statistics\_enable is true | 3600 |
-| nsd\_conf\_round\_robin | set "yes" to enable round robin | False |
-| nsd\_remote\_enable | enable remote control | false |
-| nsd\_remote\_setup | run nsd-control-setup to create keys. if false, nsd\_conf\_server\_key, nsd\_conf\_server\_cert, nsd\_conf\_control\_key and nsd\_conf\_control\_cert should be provided by the user | false |
-| nsd\_conf\_control\_interface | list of interfaces to listen on | ["127.0.0.1"] |
-| nsd\_conf\_control\_port | port for remote control | 8952 |
-| nsd\_conf\_server\_key\_file | server key | {{ nsd\_conf\_dir }}/nsd\_server.key |
-| nsd\_conf\_server\_cert\_file | server public key | {{ nsd\_conf\_dir }}/nsd\_server.pem |
-| nsd\_conf\_control\_key\_file | nsd-control key | {{ nsd\_conf\_dir }}/nsd\_control.key |
-| nsd\_conf\_control\_cert\_file | nsd-control public key | {{ nsd\_conf\_dir }}/nsd\_control.pem |
-| nsd\_conf\_server\_key | content of nsd\_server.key | "" |
-| nsd\_conf\_server\_cert | content of nsd\_server.pem | "" |
-| nsd\_conf\_control\_key | content of nsd\_control.key | "" |
-| nsd\_conf\_control\_cert | content of nsd\_control.pub | "" |
-| nsd\_zones | dict of zone date (see below) | Null |
+| `nsd_user` | `nsd` user | `{{ __nsd_user }}` |
+| `nsd_group` | `nsd` group | `{{ __nsd_group }}` |
+| `nsd_db_dir` | path to data base directory | `{{ __nsd_db_dir }}` |
+| `nsd_run_dir` | path to run directory | `{{ __nsd_run_dir }}` |
+| `nsd_state_dir` | path to state directory | `{{ __nsd_state_dir }}` |
+| `nsd_service` | service name of `nsd` | `nsd` |
+| `nsd_conf_dir` | path to config directory | `{{ __nsd_conf_dir }}` |
+| `nsd_conf` | path to `nsd.conf` | `{{ nsd_conf_dir }}/nsd.conf` |
+| `nsd_config_server` | list of configuration in `server` directive (see below) | `[]` |
+| `nsd_config_remote` | list of configuration in `remote-control` directive (see below) | `[]` |
+| `nsd_flags` | (not implemented) | `""` |
+| `nsd_remote_setup` | run `nsd-control-setup` to create self-signed keys. when false, you need to provide certificates and keys (use `reallyenglish.x509-certificate` and see an example in `tests/serverspec/remote_control_with_variables.yml` | `false` |
+| `nsd_zones` | dict of zones (see below) | `{}` |
+
+## `nsd_config_server`
+
+This variable is a list of dict or string for `server` directive in
+`nsd.conf(5)`.
+
+When an element of `nsd_config_server` is a dict, it must have a mandatory key,
+`name`. It also must have either `values` or `value` as key. The value of
+`values` is a list of string. Use `values` for options that are allowed to
+appear multiple times in `nsd.conf(5)`. The value of `value` is a string and
+used as the value for the option.
+
+When an element of `nsd_config_server` is a string, it is appended to `server`
+sections as-is.
+
+An example:
+
+```yaml
+    nsd_config_server:
+      - "server-count: 1"
+      - name: ip-address
+        values: "{{ ansible_all_ipv4_addresses }} + {{ ['127.0.0.1'] }}"
+      - name: do-ip4
+        value: "yes"
+      - name: do-ip6
+        value: "no"
+      - name: verbosity
+        value: 0
+      - name: username
+        value: "{{ nsd_user }}"
+      - name: zonesdir
+        value: '"{{ nsd_conf_dir }}"'
+      - name: database
+        value: '"{{ nsd_db_dir }}/nsd.db"'
+      - name: pidfile
+        value: '"{{ nsd_run_dir }}/nsd.pid"'
+      - name: xfrdfile
+        value: '"{{ nsd_state_dir }}/xfrd.state"'
+      - name: hide-version
+        value: "yes"
+```
+
+## `nsd_config_remote`
+
+This variable is a list of dict or string for `remote-control` directive in
+`nsd.conf(5)`.
+
+The same rules describe in `nsd_config_server` apply.
+
+## `nsd_zones`
+
+This variable is a dict of zones. Keys are domain name of zones. Each key must
+have a dict as a value, and explained below.
+
+| Key | Value | Mandatory? |
+|-----|-------|------------|
+| `zonefile` | relative path to the zone file from `nsd_conf_dir` | no |
+| `zone` | the zone definition | no |
+| `config` | list of configurations of the zone (see below) | no |
+
+`config` is a list of configurations for the zone. An element can be a dict or
+a string.
+
+When an element of `config` is a dict, the dict must have a mandatory key,
+`name`, which is one of zone options described in `nsd.conf(5)`. The dict must
+have either `values` or `value` as a key. `values` is a list of string values
+for the option. Use `values` for options that are allowed to appear multiple
+times.  `value` is a string for the option.
+
+When an element of `config` is a string, the string is simply added to the zone
+configuration.
+
+An example:
+
+```yaml
+nsd_zones:
+  example.com:
+    zonefile: example.com.zone
+    zone: |
+      example.com. 86400 IN SOA ns1.example.com. hostmaster.example.com. 2013020201 10800 3600 604800 3600
+      example.com. 86400 IN NS ns1.example.com.
+      example.com. 120 IN A 192.168.0.1
+      ns1.example.com. 120 IN A 192.168.0.1
+      mail.example.com. 120 IN A 192.168.0.1
+      example.com. 120 IN MX 25 mail.example.com.
+    config:
+      - name: provide-xfr
+        values:
+          - 192.168.133.101 my_tsig_key
+          - 127.0.0.1 NOKEY
+      - name: allow-notify
+        value: 192.168.0.111 NOKEY
+      - name: request-xfr
+        values:
+          - 192.168.0.111 NOKEY
+      - name: outgoing-interface
+        values:
+          - 192.168.0.1
+      - 'allow-axfr-fallback: yes'
+```
 
 ## Debian
 
 | Variable | Default |
 |----------|---------|
-| \_\_nsd\_user | nsd |
-| \_\_nsd\_group | nsd |
-| \_\_nsd\_db\_dir | /var/lib/nsd |
-| \_\_nsd\_conf\_dir | /etc/nsd |
-| \_\_nsd\_run\_dir | /var/run/nsd |
-| \_\_nsd\_state\_dir | /var/lib/nsd |
+| `__nsd_user` | `nsd` |
+| `__nsd_group` | `nsd` |
+| `__nsd_db_dir` | `/var/lib/nsd` |
+| `__nsd_conf_dir` | `/etc/nsd` |
+| `__nsd_run_dir` | `/var/run/nsd` |
+| `__nsd_state_dir` | `{{ __nsd_db_dir }}` |
 
 ## FreeBSD
 
 | Variable | Default |
 |----------|---------|
-| \_\_nsd\_user | nsd |
-| \_\_nsd\_group | nsd |
-| \_\_nsd\_db\_dir | /var/db/nsd |
-| \_\_nsd\_conf\_dir | /usr/local/etc/nsd |
-| \_\_nsd\_run\_dir | /var/run/nsd |
-| \_\_nsd\_state\_dir | /var/db/nsd |
+| `__nsd_user` | `nsd` |
+| `__nsd_group` | `nsd` |
+| `__nsd_db_dir` | `/var/db/nsd` |
+| `__nsd_conf_dir` | `/usr/local/etc/nsd` |
+| `__nsd_run_dir` | `/var/run/nsd` |
+| `__nsd_state_dir` | `{{ __nsd_db_dir }}` |
 
 ## OpenBSD
 
 | Variable | Default |
 |----------|---------|
-| \_\_nsd\_user | \_nsd |
-| \_\_nsd\_group | \_nsd |
-| \_\_nsd\_db\_dir | /var/nsd/db |
-| \_\_nsd\_conf\_dir | /var/nsd/etc |
-| \_\_nsd\_run\_dir | /var/nsd/run |
-| \_\_nsd\_state\_dir | /var/nsd/run |
+| `__nsd_user` | `_nsd` |
+| `__nsd_group` | `_nsd` |
+| `__nsd_db_dir` | `/var/nsd/db` |
+| `__nsd_conf_dir` | `/var/nsd/etc` |
+| `__nsd_run_dir` | `/var/nsd/run` |
+| `__nsd_state_dir` | `{{ __nsd_run_dir }}` |
 
 ## RedHat
 
 | Variable | Default |
 |----------|---------|
-| \_\_nsd\_user | nsd |
-| \_\_nsd\_group | nsd |
-| \_\_nsd\_db\_dir | /var/lib/nsd |
-| \_\_nsd\_conf\_dir | /etc/nsd |
-| \_\_nsd\_run\_dir | /var/run/nsd |
-| \_\_nsd\_state\_dir | /var/lib/nsd |
-
-Created by [yaml2readme.rb](https://gist.github.com/trombik/b2df709657c08d845b1d3b3916e592d3)
+| `__nsd_user` | `nsd` |
+| `__nsd_group` | `nsd` |
+| `__nsd_db_dir` | `/var/lib/nsd` |
+| `__nsd_conf_dir` | `/etc/nsd` |
+| `__nsd_run_dir` | `/var/run/nsd` |
+| `__nsd_state_dir` | `{{ __nsd_db_dir }}` |
 
 # Dependencies
 
@@ -105,54 +183,88 @@ None
 
 # Example Playbook
 
-## Master DNS
+```yaml
+- hosts: localhost
+  roles:
+    - ansible-role-nsd
+  vars:
+    nsd_config_server:
+      - "server-count: 1"
+      - name: ip-address
+        values: "{{ ansible_all_ipv4_addresses }} + {{ ['127.0.0.1'] }}"
+      - name: do-ip4
+        value: "yes"
+      - name: do-ip6
+        value: "no"
+      - name: verbosity
+        value: 0
+      - name: username
+        value: "{{ nsd_user }}"
+      - name: zonesdir
+        value: '"{{ nsd_conf_dir }}"'
+      - name: database
+        value: '"{{ nsd_db_dir }}/nsd.db"'
+      - name: pidfile
+        value: '"{{ nsd_run_dir }}/nsd.pid"'
+      - name: xfrdfile
+        value: '"{{ nsd_state_dir }}/xfrd.state"'
+      - name: hide-version
+        value: "yes"
+    nsd_remote_enable: "{% if ansible_os_family == 'FreeBSD' %}False{% else %}true{% endif %}"
+    nsd_remote_setup: "{% if ansible_os_family == 'FreeBSD' %}False{% else %}true{% endif %}"
+    nsd_config_remote:
+      - "control-enable: {% if ansible_os_family == 'FreeBSD' %}no{% else %}yes{% endif %}"
+    nsd_keys:
+      my_tsig_key:
+        secret: Qes2X7V8Fjg+EMlqng1qlCvErGFxXWa4Gxfy1uDWKvQ=
+        algorithm: hmac-sha256
+    nsd_zones:
+      example.com:
+        zonefile: example.com.zone
+        zone: |
+          example.com. 86400 IN SOA ns1.example.com. hostmaster.example.com. 2013020201 10800 3600 604800 3600
+          example.com. 86400 IN NS ns1.example.com.
+          example.com. 120 IN A 192.168.0.1
+          ns1.example.com. 120 IN A 192.168.0.1
+          mail.example.com. 120 IN A 192.168.0.1
+          example.com. 120 IN MX 25 mail.example.com.
+        config:
+          - name: provide-xfr
+            values:
+              - 192.168.133.101 my_tsig_key
+              - 127.0.0.1 NOKEY
+          - name: allow-notify
+            values:
+              - 192.168.0.111 NOKEY
+          - name: request-xfr
+            values:
+              - 192.168.0.111 NOKEY
+          - name: outgoing-interface
+            values:
+              - 192.168.0.1
+          - 'allow-axfr-fallback: yes'
+      example.net:
+        zonefile: example.net.zone
+        zone: |
+          example.net. 86400 IN SOA ns1.example.net. hostmaster.example.net. 2013020201 10800 3600 604800 3600
+          example.net. 86400 IN NS ns1.example.net.
+          example.net. 120 IN A 192.168.0.1
+          ns1.example.net. 120 IN A 192.168.0.1
+          mail.example.net. 120 IN A 192.168.0.1
+          example.net. 120 IN MX 25 mail.example.net.
+        config: []
 
-      - hosts: localhost
-        roles:
-          - ansible-role-nsd
-        vars:
-          nsd_keys:
-            my_tsig_key:
-              secret: Qes2X7V8Fjg+EMlqng1qlCvErGFxXWa4Gxfy1uDWKvQ=
-              algorithm: hmac-sha256
-          nsd_zones:
-            example.com:
-              zonefile: example.com.zone
-              zone: |
-                example.com. 86400 IN SOA ns1.example.com. hostmaster.example.com. 2013020201 10800 3600 604800 3600
-                example.com. 86400 IN NS ns1.example.com.
-                example.com. 120 IN A 192.168.0.1
-                ns1.example.com. 120 IN A 192.168.0.1
-                mail.example.com. 120 IN A 192.168.0.1
-                example.com. 120 IN MX 25 mail.example.com.
-              provide_xfr:
-                - 192.168.133.101 my_tsig_key
-                - 127.0.0.1 NOKEY
+    redhat_repo_extra_packages:
+      - epel-release
+    redhat_repo:
+      epel:
+        mirrorlist: "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-{{ ansible_distribution_major_version | default(7) }}&arch={{ ansible_architecture }}"
+        gpgcheck: yes
+        enabled: yes
+```
 
-* allow secure AXFR from 192.168.133.101
-* allow insecure AXFR from localhost
-
-## Slave
-
-      - hosts: localhost
-        roles:
-          - ansible-role-nsd
-        vars:
-          nsd_keys:
-            my_tsig_key:
-              secret: Qes2X7V8Fjg+EMlqng1qlCvErGFxXWa4Gxfy1uDWKvQ=
-              algorithm: hmac-sha256
-          nsd_conf_control_enable: "yes"
-          nsd_remote_enable: true
-          nsd_remote_setup: true
-          nsd_zones:
-            example.com:
-              request_xfr:
-                - 192.168.133.100 my_tsig_key
-
-* enable remote control
-* setup keys for remote control automatically
-* request AXFR with TSIG key
+Master-slave example can be found at
+[tests/integration/example](https://github.com/reallyenglish/ansible-role-nsd/tree/master/tests/integration/example).
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ it, other platforms do not require it.
 | `nsd_conf_dir` | path to config directory | `{{ __nsd_conf_dir }}` |
 | `nsd_conf` | path to `nsd.conf` | `{{ nsd_conf_dir }}/nsd.conf` |
 | `nsd_config_server` | list of configuration in `server` directive (see below) | `[]` |
-| `nsd_config_remote` | list of configuration in `remote-control` directive (see below) | `[]` |
+| `nsd_config_remote_control` | list of configuration in `remote-control` directive (see below) | `[]` |
 | `nsd_flags` | (not implemented) | `""` |
 | `nsd_remote_setup` | run `nsd-control-setup` to create self-signed keys. when false, you need to provide certificates and keys (use `reallyenglish.x509-certificate` and see an example in `tests/serverspec/remote_control_with_variables.yml` | `false` |
 | `nsd_zones` | dict of zones (see below) | `{}` |
@@ -74,7 +74,7 @@ An example:
         value: "yes"
 ```
 
-## `nsd_config_remote`
+## `nsd_config_remote_control`
 
 This variable is a list of dict or string for `remote-control` directive in
 `nsd.conf(5)`.
@@ -212,7 +212,7 @@ None
         value: "yes"
     nsd_remote_enable: "{% if ansible_os_family == 'FreeBSD' %}False{% else %}true{% endif %}"
     nsd_remote_setup: "{% if ansible_os_family == 'FreeBSD' %}False{% else %}true{% endif %}"
-    nsd_config_remote:
+    nsd_config_remote_control:
       - "control-enable: {% if ansible_os_family == 'FreeBSD' %}no{% else %}yes{% endif %}"
     nsd_keys:
       my_tsig_key:

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ nsd_zones:
 | `__nsd_db_dir` | `/var/lib/nsd` |
 | `__nsd_conf_dir` | `/etc/nsd` |
 | `__nsd_run_dir` | `/var/run/nsd` |
-| `__nsd_state_dir` | `{{ __nsd_db_dir }}` |
+| `__nsd_state_dir` | `{{ nsd_db_dir }}` |
 
 ## FreeBSD
 
@@ -153,7 +153,7 @@ nsd_zones:
 | `__nsd_db_dir` | `/var/db/nsd` |
 | `__nsd_conf_dir` | `/usr/local/etc/nsd` |
 | `__nsd_run_dir` | `/var/run/nsd` |
-| `__nsd_state_dir` | `{{ __nsd_db_dir }}` |
+| `__nsd_state_dir` | `{{ nsd_db_dir }}` |
 
 ## OpenBSD
 
@@ -164,7 +164,7 @@ nsd_zones:
 | `__nsd_db_dir` | `/var/nsd/db` |
 | `__nsd_conf_dir` | `/var/nsd/etc` |
 | `__nsd_run_dir` | `/var/nsd/run` |
-| `__nsd_state_dir` | `{{ __nsd_run_dir }}` |
+| `__nsd_state_dir` | `{{ nsd_run_dir }}` |
 
 ## RedHat
 
@@ -175,7 +175,7 @@ nsd_zones:
 | `__nsd_db_dir` | `/var/lib/nsd` |
 | `__nsd_conf_dir` | `/etc/nsd` |
 | `__nsd_run_dir` | `/var/run/nsd` |
-| `__nsd_state_dir` | `{{ __nsd_db_dir }}` |
+| `__nsd_state_dir` | `{{ nsd_db_dir }}` |
 
 # Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ nsd_service: nsd
 nsd_conf_dir: "{{ __nsd_conf_dir }}"
 nsd_conf: "{{ nsd_conf_dir }}/nsd.conf"
 nsd_config_server: []
-nsd_config_remote: []
+nsd_config_remote_control: []
 nsd_flags: ""
 nsd_remote_setup: false
 # master and slave

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,4 +11,4 @@ nsd_config_remote: []
 nsd_flags: ""
 nsd_remote_setup: false
 # master and slave
-nsd_zones:
+nsd_zones: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,10 +9,6 @@ nsd_conf: "{{ nsd_conf_dir }}/nsd.conf"
 nsd_config_server: []
 nsd_config_remote: []
 nsd_flags: ""
-
-nsd_chroot_enable: false
-nsd_chroot_dir: "{{ nsd_conf_dir }}"
-
 nsd_remote_setup: false
 # master and slave
 nsd_zones:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,26 +6,14 @@ nsd_state_dir: "{{ __nsd_state_dir }}"
 nsd_service: nsd
 nsd_conf_dir: "{{ __nsd_conf_dir }}"
 nsd_conf: "{{ nsd_conf_dir }}/nsd.conf"
+nsd_config_server: []
+nsd_config_remote: []
 nsd_flags: ""
 
 nsd_chroot_enable: false
 nsd_chroot_dir: "{{ nsd_conf_dir }}"
-nsd_statistics_enable: false
-nsd_ip_addresses:
-nsd_listen_on_localhost: true
 
-nsd_conf_do_ip4: "yes"
-nsd_conf_do_ip6: "no"
-nsd_conf_verbosity: 0
-nsd_conf_zonesdir: "{{ nsd_conf_dir }}"
-nsd_conf_statistics: 3600
-nsd_conf_round_robin: False
-nsd_conf_server_count: 1
-
-nsd_remote_enable: false
 nsd_remote_setup: false
-nsd_conf_control_interface: [ 127.0.0.1 ]
-nsd_conf_control_port: 8952
 
 nsd_conf_server_key_file:   "{{ nsd_conf_dir }}/nsd_server.key"
 nsd_conf_server_cert_file:  "{{ nsd_conf_dir }}/nsd_server.pem"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,16 +14,5 @@ nsd_chroot_enable: false
 nsd_chroot_dir: "{{ nsd_conf_dir }}"
 
 nsd_remote_setup: false
-
-nsd_conf_server_key_file:   "{{ nsd_conf_dir }}/nsd_server.key"
-nsd_conf_server_cert_file:  "{{ nsd_conf_dir }}/nsd_server.pem"
-nsd_conf_control_key_file:  "{{ nsd_conf_dir }}/nsd_control.key"
-nsd_conf_control_cert_file: "{{ nsd_conf_dir }}/nsd_control.pem"
-
-nsd_conf_server_key:   ""
-nsd_conf_server_cert:  ""
-nsd_conf_control_key:  ""
-nsd_conf_control_cert: ""
-
 # master and slave
 nsd_zones:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,13 +12,16 @@ galaxy_info:
   - name: OpenBSD
     versions:
     - 6.0
+    - 6.1
   - name: Ubuntu
     versions:
     - trusty
+    - xenial
   - name: EL
     versions:
     - 7
   galaxy_tags:
+    - nsd
     - DNS
 dependencies:
 # XXX until all ansible version is upgraded to the one that supports new

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,1 +1,2 @@
 - name: reallyenglish.redhat-repo
+- name: reallyenglish.x509-certificate

--- a/tasks/configure-remote.yml
+++ b/tasks/configure-remote.yml
@@ -6,49 +6,5 @@
     creates: "{{ nsd_conf_dir }}/nsd_control.key"
   when: nsd_remote_setup
 
-- name: Create nsd_server.key
-  template:
-    src: nsd_server.key.j2
-    dest: "{{ nsd_conf_server_key_file }}"
-    mode: 0600
-    owner: "{{ nsd_user }}"
-    group: "{{ nsd_group }}"
-    validate: openssl rsa -in %s -check
-  notify: Restart nsd
-  when: not nsd_remote_setup
-
-- name: Create nsd_server.pem
-  template:
-    src: nsd_server.pem.j2
-    dest: "{{ nsd_conf_server_cert_file }}"
-    mode: 0644
-    owner: "{{ nsd_user }}"
-    group: "{{ nsd_group }}"
-    validate: openssl x509 -in %s -text -noout
-  notify: Restart nsd
-  when: not nsd_remote_setup
-
-- name: Create nsd_control.key
-  template:
-    src: nsd_control.key.j2
-    dest: "{{ nsd_conf_control_key_file }}"
-    mode: 0600
-    owner: "{{ nsd_user }}"
-    group: "{{ nsd_group }}"
-    validate: openssl rsa -in %s -check
-  notify: Restart nsd
-  when: not nsd_remote_setup
-
-- name: Create nsd_control.pem
-  template:
-    src: nsd_control.pem.j2
-    dest: "{{ nsd_conf_control_cert_file }}"
-    mode: 0644
-    owner: "{{ nsd_user }}"
-    group: "{{ nsd_group }}"
-    validate: openssl x509 -in %s -text -noout
-  notify: Restart nsd
-  when: not nsd_remote_setup
-
 - include: "configure-remote-RedHat.yml"
   when: ansible_os_family == 'RedHat'

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -5,6 +5,11 @@
     name: nsd
     state: present
 
+- name: Enable nsd
+  service:
+    name: "{{ nsd_service }}"
+    enabled: true
+
 - name: Install ldnsutils
   apt:
     name: ldnsutils

--- a/tasks/install-FreeBSD.yml
+++ b/tasks/install-FreeBSD.yml
@@ -4,3 +4,8 @@
   pkgng:
     name: nsd
     state: present
+
+- name: Enable nsd
+  service:
+    name: "{{ nsd_service }}"
+    enabled: true

--- a/tasks/install-OpenBSD.yml
+++ b/tasks/install-OpenBSD.yml
@@ -4,3 +4,8 @@
   openbsd_pkg:
     name: drill
     state: present
+
+- name: Enable nsd
+  service:
+    name: "{{ nsd_service }}"
+    enabled: true

--- a/tasks/install-RedHat.yml
+++ b/tasks/install-RedHat.yml
@@ -5,6 +5,11 @@
     name: nsd
     state: present
 
+- name: Enable nsd
+  service:
+    name: "{{ nsd_service }}"
+    enabled: true
+
 - name: Install ldnsutils
   yum:
     name: ldns

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,5 +46,4 @@
 - name: Start nsd
   service:
     name: "{{ nsd_service }}"
-    enabled: true
     state: started

--- a/templates/nsd.conf.j2
+++ b/templates/nsd.conf.j2
@@ -14,7 +14,7 @@ server:
 {% endfor %}
 
 remote-control:
-{% for l in nsd_config_remote %}
+{% for l in nsd_config_remote_control %}
 {% if l | isdict %}
 {% if 'value' in l %}
     {{ l['name'] }}: {{ l['value'] }}

--- a/templates/nsd.conf.j2
+++ b/templates/nsd.conf.j2
@@ -37,7 +37,9 @@ key:
 zone:
 {% for k, v in nsd_zones | dictsort %}
     name: {{ k }}
+{% if 'zonefile' in v %}
     zonefile: {{ v.zonefile }}
+{% endif %}
 {% for l in v.config %}
 {% if l | isdict %}
 {% if 'value' in l %}

--- a/templates/nsd.conf.j2
+++ b/templates/nsd.conf.j2
@@ -1,50 +1,32 @@
 server:
-    # Number of NSD servers to fork.  Put the number of CPUs to use here.
-    server-count: {{ nsd_conf_server_count }}
-{% set ip_addresses = nsd_ip_addresses if nsd_ip_addresses  else ansible_all_ipv4_addresses %}
-{% for ip in ip_addresses %}
-    ip-address: {{ ip }}
+{% for l in nsd_config_server %}
+{% if l | isdict %}
+{% if 'value' in l %}
+  {{ l['name'] }}: {{ l['value'] }}
+{% elif 'values' in l %}
+{% for value in l['values'] %}
+  {{ l['name'] }}: {{ value }}
 {% endfor %}
-{% if nsd_listen_on_localhost %}
-    ip-address: 127.0.0.1
 {% endif %}
-    do-ip4: {{ nsd_conf_do_ip4 }}
-    do-ip6: {{ nsd_conf_do_ip6 }}
-    verbosity: {{ nsd_conf_verbosity }}
-    username: {{ nsd_user }}
-{# some distributions have older nsd package that does not support round-robin #}
-{% if nsd_conf_round_robin %}
-    round-robin: {{ nsd_conf_round_robin }}
+{% else %}
+  {{ l }}
 {% endif %}
+{% endfor %}
 
-{% if nsd_chroot_enable %}
-    chroot: "{{ nsd_conf_dir }}"
-{% endif %}
-    zonesdir: "{{ nsd_conf_zonesdir }}"
-
-    # the list of dynamically added zones.
-    # zonelistfile: "/var/db/nsd/zone.list"
-
-    database: "{{ nsd_db_dir }}/nsd.db"
-    pidfile: "{{ nsd_run_dir }}/nsd.pid"
-    xfrdfile: "{{ nsd_state_dir }}/xfrd.state"
-    hide-version: yes
-{% if nsd_statistics_enable %}
-    statistics: {{ nsd_conf_statistics }}
-{% endif %}
-
-{% if nsd_remote_enable %}
 remote-control:
-    control-enable: yes
-{% for i in nsd_conf_control_interface %}
-    control-interface: {{ i }}
+{% for l in nsd_config_remote %}
+{% if l | isdict %}
+{% if 'value' in l %}
+    {{ l['name'] }}: {{ l['value'] }}
+{% elif 'values' in l %}
+{% for value in l['values'] %}
+    {{ l['name'] }}: {{ value }}
 {% endfor %}
-    control-port: {{ nsd_conf_control_port }}
-    server-key-file: "{{ nsd_conf_server_key_file }}"
-    server-cert-file: "{{ nsd_conf_server_cert_file }}"
-    control-key-file: "{{ nsd_conf_control_key_file }}"
-    control-cert-file: "{{ nsd_conf_control_cert_file }}"
 {% endif %}
+{% else %}
+    {{ l }}
+{% endif %}
+{% endfor %}
 
 key:
 {% for k, v in nsd_keys | dictsort %}
@@ -54,34 +36,19 @@ key:
 
 zone:
 {% for k, v in nsd_zones | dictsort %}
-    name: "{{ k }}"
-{% if 'include_pattern' in v %}
-    include-pattern: "{{ v['include_pattern'] }}"
-{%-  endif %}
-{% if 'zonefile' in v %}
-    zonefile: "{{ v['zonefile'] }}"
+    name: {{ k }}
+    zonefile: {{ v.zonefile }}
+{% for l in v.config %}
+{% if l | isdict %}
+{% if 'value' in l %}
+    {{ l['name'] }}: {{ l['value'] }}
+{% elif 'values' in l %}
+{% for value in l['values'] %}
+    {{ l['name'] }}: {{ value }}
+{% endfor %}
 {% endif %}
-{% if 'allow_notify' in v %}
-{%  for acl in v['allow_notify'] %}
-    allow-notify: {{ acl }}
-{%  endfor %}
+{% else %}
+    {{ l }}
 {% endif %}
-{% if 'provide_xfr' in v %}
-{%  for xfr in v['provide_xfr'] %}
-    provide-xfr: {{ xfr }}
-{%  endfor %}
-{% endif %}
-{% if 'request_xfr' in v %}
-{%  for xfr in v['request_xfr'] %}
-    request-xfr: {{ xfr }}
-{%  endfor %}
-{% endif %}
-{% if 'allow_axfr_fallback' in v %}
-    allow-axfr-fallback: "{{ v['allow_axfr_fallback'] }}"
-{% endif %}
-{% if 'outgoing_interface' in v %}
-{%  for acl in v['outgoing_interface'] %}
-    outgoing-interface: {{ acl }}
-{%  endfor %}
-{% endif %}
+{% endfor %}
 {% endfor %}

--- a/templates/nsd.conf.j2
+++ b/templates/nsd.conf.j2
@@ -34,8 +34,8 @@ key:
     include: "{{ nsd_conf_dir }}/{{ k }}.key"
 {% endfor %}
 
-zone:
 {% for k, v in nsd_zones | dictsort %}
+zone:
     name: {{ k }}
 {% if 'zonefile' in v %}
     zonefile: {{ v.zonefile }}

--- a/test_plugins/object_type.py
+++ b/test_plugins/object_type.py
@@ -1,0 +1,19 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible import errors
+
+def isdict(x):
+    return bool(isinstance(x, dict))
+
+def islist(x):
+    return bool(isinstance(x, list))
+
+class TestModule(object):
+    ''' Ansible file jinja2 tests to test object types'''
+
+    def tests(self):
+        return {
+            'isdict' : isdict,
+            'islist' : islist,
+        }

--- a/tests/integration/example/group_vars/master
+++ b/tests/integration/example/group_vars/master
@@ -15,6 +15,8 @@ nsd_zones:
       ns1.example.com. 120 IN A 192.168.0.1
       mail.example.com. 120 IN A 192.168.0.1
       example.com. 120 IN MX 25 mail.example.com.
-    provide_xfr:
-      - 192.168.133.101 my_tsig_key
-      - 127.0.0.1 NOKEY
+    config:
+      - name: provide-xfr
+        values:
+          - 192.168.133.101 my_tsig_key
+          - 127.0.0.1 NOKEY

--- a/tests/integration/example/group_vars/slave
+++ b/tests/integration/example/group_vars/slave
@@ -7,5 +7,6 @@ nsd_remote_enable: true
 nsd_remote_setup: true
 nsd_zones:
   example.com:
-    request_xfr:
-      - 192.168.133.100 my_tsig_key
+    config:
+      - name: request-xfr
+        value: 192.168.133.100 my_tsig_key

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -57,6 +57,16 @@
             values:
               - 192.168.0.1
           - 'allow-axfr-fallback: yes'
+      example.net:
+        zonefile: example.net.zone
+        zone: |
+          example.net. 86400 IN SOA ns1.example.net. hostmaster.example.net. 2013020201 10800 3600 604800 3600
+          example.net. 86400 IN NS ns1.example.net.
+          example.net. 120 IN A 192.168.0.1
+          ns1.example.net. 120 IN A 192.168.0.1
+          mail.example.net. 120 IN A 192.168.0.1
+          example.net. 120 IN MX 25 mail.example.net.
+        config: ""
 
     redhat_repo_extra_packages:
       - epel-release

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -66,7 +66,7 @@
           ns1.example.net. 120 IN A 192.168.0.1
           mail.example.net. 120 IN A 192.168.0.1
           example.net. 120 IN MX 25 mail.example.net.
-        config: ""
+        config: []
 
     redhat_repo_extra_packages:
       - epel-release

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -48,8 +48,7 @@
               - 192.168.133.101 my_tsig_key
               - 127.0.0.1 NOKEY
           - name: allow-notify
-            values:
-              - 192.168.0.111 NOKEY
+            value: 192.168.0.111 NOKEY
           - name: request-xfr
             values:
               - 192.168.0.111 NOKEY

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -2,8 +2,32 @@
   roles:
     - ansible-role-nsd
   vars:
+    nsd_config_server:
+      - "server-count: 1"
+      - name: ip-address
+        values: "{{ ansible_all_ipv4_addresses }} + {{ ['127.0.0.1'] }}"
+      - name: do-ip4
+        value: "yes"
+      - name: do-ip6
+        value: "no"
+      - name: verbosity
+        value: 0
+      - name: username
+        value: "{{ nsd_user }}"
+      - name: zonesdir
+        value: '"{{ nsd_conf_dir }}"'
+      - name: database
+        value: '"{{ nsd_db_dir }}/nsd.db"'
+      - name: pidfile
+        value: '"{{ nsd_run_dir }}/nsd.pid"'
+      - name: xfrdfile
+        value: '"{{ nsd_state_dir }}/xfrd.state"'
+      - name: hide-version
+        value: "yes"
     nsd_remote_enable: "{% if ansible_os_family == 'FreeBSD' %}False{% else %}true{% endif %}"
     nsd_remote_setup: "{% if ansible_os_family == 'FreeBSD' %}False{% else %}true{% endif %}"
+    nsd_config_remote:
+      - "control-enable: {% if ansible_os_family == 'FreeBSD' %}no{% else %}yes{% endif %}"
     nsd_keys:
       my_tsig_key:
         secret: Qes2X7V8Fjg+EMlqng1qlCvErGFxXWa4Gxfy1uDWKvQ=
@@ -18,16 +42,21 @@
           ns1.example.com. 120 IN A 192.168.0.1
           mail.example.com. 120 IN A 192.168.0.1
           example.com. 120 IN MX 25 mail.example.com.
-        provide_xfr:
-          - 192.168.133.101 my_tsig_key
-          - 127.0.0.1 NOKEY
-        allow_notify:
-          - 192.168.0.111 NOKEY
-        request_xfr:
-          - 192.168.0.111 NOKEY
-        outgoing_interface:
-          - 192.168.0.1
-        allow_axfr_fallback: "yes"
+        config:
+          - name: provide-xfr
+            values:
+              - 192.168.133.101 my_tsig_key
+              - 127.0.0.1 NOKEY
+          - name: allow-notify
+            values:
+              - 192.168.0.111 NOKEY
+          - name: request-xfr
+            values:
+              - 192.168.0.111 NOKEY
+          - name: outgoing-interface
+            values:
+              - 192.168.0.1
+          - 'allow-axfr-fallback: yes'
 
     redhat_repo_extra_packages:
       - epel-release

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -26,7 +26,7 @@
         value: "yes"
     nsd_remote_enable: "{% if ansible_os_family == 'FreeBSD' %}False{% else %}true{% endif %}"
     nsd_remote_setup: "{% if ansible_os_family == 'FreeBSD' %}False{% else %}true{% endif %}"
-    nsd_config_remote:
+    nsd_config_remote_control:
       - "control-enable: {% if ansible_os_family == 'FreeBSD' %}no{% else %}yes{% endif %}"
     nsd_keys:
       my_tsig_key:

--- a/tests/serverspec/default_spec.rb
+++ b/tests/serverspec/default_spec.rb
@@ -51,7 +51,7 @@ describe file(config) do
   its(:content) { should_not match(/^chroot: /) }
   its(:content) { should_not match(/^key:\n\+name: my_tsig_key\n\s+include: "#{Regexp.escape("/usr/local/etc/nsd/my_tsig_key.key")}"/) }
 
-  zone = <<-__EOF__
+  zone_com = <<-__EOF__
     name: example.com
     zonefile: example.com.zone
     provide-xfr: 192.168.133.101 my_tsig_key
@@ -61,7 +61,14 @@ describe file(config) do
     outgoing-interface: 192.168.0.1
     allow-axfr-fallback: yes
   __EOF__
-  its(:content) { should match(/^zone:\n#{zone}/) }
+  its(:content) { should match(/^zone:\n#{zone_com}/) }
+
+  zone_net = <<-__EOF__
+    name: example.net
+    zonefile: example.net.zone
+  __EOF__
+  its(:content) { should match(/^zone:\n#{zone_net}/) }
+
   its(:content_as_yaml) { should include("remote-control" => include("control-enable" => os[:family] == "freebsd" ? false : true)) }
   its(:content) { should_not match(/round-robin:/) }
   if os[:family] == "freebsd"

--- a/tests/serverspec/default_spec.rb
+++ b/tests/serverspec/default_spec.rb
@@ -40,16 +40,29 @@ describe file(config) do
   it { should be_file }
   its(:content) { should match(/ip-address: 10\.0\.2\./) }
   its(:content) { should match(/ip-address: 127\.0\.0\.1/) }
-  its(:content) { should match(/do-ip4: yes/) }
-  its(:content) { should match(/do-ip6: no/) }
-  its(:content) { should match(/verbosity: 0/) }
-  its(:content) { should match(/username: #{user}/) }
-  its(:content) { should_not match(/chroot: /) }
-  its(:content) { should include(%(zonesdir: "#{config_dir}")) }
-  its(:content) { should include(%(database: "#{db_dir}/nsd.db")) }
-  its(:content) { should include(%(pidfile: "#{run_dir}/nsd.pid")) }
-  its(:content) { should include(%(xfrdfile: "#{state_dir}/xfrd.state")) }
-  its(:content) { should match(/verbosity: 0/) }
+  its(:content_as_yaml) { should include("server" => include("do-ip4" => true)) }
+  its(:content_as_yaml) { should include("server" => include("do-ip6" => false)) }
+  its(:content_as_yaml) { should include("server" => include("verbosity" => 0)) }
+  its(:content_as_yaml) { should include("server" => include("username" => user)) }
+  its(:content_as_yaml) { should include("server" => include("zonesdir" => config_dir)) }
+  its(:content_as_yaml) { should include("server" => include("database" => "#{db_dir}/nsd.db")) }
+  its(:content_as_yaml) { should include("server" => include("pidfile" => "#{run_dir}/nsd.pid")) }
+  its(:content_as_yaml) { should include("server" => include("xfrdfile" => "#{state_dir}/xfrd.state")) }
+  its(:content) { should_not match(/^chroot: /) }
+  its(:content) { should_not match(/^key:\n\+name: my_tsig_key\n\s+include: "#{Regexp.escape("/usr/local/etc/nsd/my_tsig_key.key")}"/) }
+
+  zone = <<-__EOF__
+    name: example.com
+    zonefile: example.com.zone
+    provide-xfr: 192.168.133.101 my_tsig_key
+    provide-xfr: 127.0.0.1 NOKEY
+    allow-notify: 192.168.0.111 NOKEY
+    request-xfr: 192.168.0.111 NOKEY
+    outgoing-interface: 192.168.0.1
+    allow-axfr-fallback: yes
+  __EOF__
+  its(:content) { should match(/^zone:\n#{zone}/) }
+  its(:content_as_yaml) { should include("remote-control" => include("control-enable" => os[:family] == "freebsd" ? false : true)) }
   its(:content) { should_not match(/round-robin:/) }
   if os[:family] == "freebsd"
     its(:content) { should_not match(/control-enable: yes/) }

--- a/tests/serverspec/remote_control.yml
+++ b/tests/serverspec/remote_control.yml
@@ -13,14 +13,6 @@
         value: 127.0.0.1
       - name: control-port
         value: 8952
-      - name: server-key-file
-        value: '"{{ nsd_conf_server_key_file }}"'
-      - name: server-cert-file
-        value: '"{{ nsd_conf_server_cert_file }}"'
-      - name: control-key-file
-        value: '"{{ nsd_conf_control_key_file }}"'
-      - name:  control-cert-file
-        value: '"{{ nsd_conf_control_cert_file }}"'
     nsd_conf_control_enable: "yes"
     nsd_remote_enable: true
     nsd_remote_setup: true

--- a/tests/serverspec/remote_control.yml
+++ b/tests/serverspec/remote_control.yml
@@ -7,7 +7,7 @@
       my_tsig_key:
         secret: Qes2X7V8Fjg+EMlqng1qlCvErGFxXWa4Gxfy1uDWKvQ=
         algorithm: hmac-sha256
-    nsd_config_remote:
+    nsd_config_remote_control:
       - "control-enable: yes"
       - name: control-interface
         value: 127.0.0.1

--- a/tests/serverspec/remote_control.yml
+++ b/tests/serverspec/remote_control.yml
@@ -7,13 +7,37 @@
       my_tsig_key:
         secret: Qes2X7V8Fjg+EMlqng1qlCvErGFxXWa4Gxfy1uDWKvQ=
         algorithm: hmac-sha256
+    nsd_config_remote:
+      - "control-enable: yes"
+      - name: control-interface
+        value: 127.0.0.1
+      - name: control-port
+        value: 8952
+      - name: server-key-file
+        value: '"{{ nsd_conf_server_key_file }}"'
+      - name: server-cert-file
+        value: '"{{ nsd_conf_server_cert_file }}"'
+      - name: control-key-file
+        value: '"{{ nsd_conf_control_key_file }}"'
+      - name:  control-cert-file
+        value: '"{{ nsd_conf_control_cert_file }}"'
     nsd_conf_control_enable: "yes"
     nsd_remote_enable: true
     nsd_remote_setup: true
     nsd_zones:
       example.com:
-        request_xfr:
-          - 192.168.133.100 my_tsig_key
+        zonefile: example.com.zone
+        zone: |
+          example.com. 86400 IN SOA ns1.example.com. hostmaster.example.com. 2013020201 10800 3600 604800 3600
+          example.com. 86400 IN NS ns1.example.com.
+          example.com. 120 IN A 192.168.0.1
+          ns1.example.com. 120 IN A 192.168.0.1
+          mail.example.com. 120 IN A 192.168.0.1
+          example.com. 120 IN MX 25 mail.example.com.
+        config:
+          - name: request-xfr
+            values:
+              - 192.168.133.100 my_tsig_key
 
     redhat_repo_extra_packages:
       - epel-release

--- a/tests/serverspec/remote_control_spec.rb
+++ b/tests/serverspec/remote_control_spec.rb
@@ -30,10 +30,6 @@ describe file(config) do
   its(:content) { should match(/control-enable: yes/) }
   its(:content) { should match(/control-interface: 127\.0\.0\.1/) }
   its(:content) { should match(/control-port: 8952/) }
-  its(:content) { should match Regexp.escape("server-key-file: \"#{config_dir}/nsd_server.key\"") }
-  its(:content) { should match Regexp.escape("server-cert-file: \"#{config_dir}/nsd_server.pem\"") }
-  its(:content) { should match Regexp.escape("control-key-file: \"#{config_dir}/nsd_control.key\"") }
-  its(:content) { should match Regexp.escape("control-cert-file: \"#{config_dir}/nsd_control.pem\"") }
 end
 
 %w(nsd_server.key nsd_control.key).each do |f|

--- a/tests/serverspec/remote_control_with_variables.yml
+++ b/tests/serverspec/remote_control_with_variables.yml
@@ -1,8 +1,165 @@
 - hosts: localhost
   roles:
     - reallyenglish.redhat-repo
+    - reallyenglish.x509-certificate
     - ansible-role-nsd
   vars:
+    x509_certificate_additional_packages: "{% if ansible_os_family == 'OpenBSD' %}[]{% else %}nsd{% endif %}"
+    # XXX nsd_conf_dir_pre == nsd_conf_dir
+    # when x509-certificate is applied to the host, `nsd_conf_dir` is not
+    # included yet.
+    nsd_conf_dir_pre: "{% if ansible_os_family == 'OpenBSD' %}/var/nsd/etc{% elif ansible_os_family == 'FreeBSD' %}/usr/local/etc/nsd{% else %}/etc/nsd{% endif %}"
+    x509_certificate:
+      - name: nsd_control
+        state: present
+        public:
+          path: "{{ nsd_conf_dir_pre }}/nsd_control.pem"
+          owner: "{% if ansible_os_family == 'OpenBSD' %}_nsd{% else %}nsd{% endif %}"
+          group: "{% if ansible_os_family == 'OpenBSD' %}_nsd{% else %}nsd{% endif %}"
+          mode: "0644"
+          key: |
+            -----BEGIN CERTIFICATE-----
+            MIIDoDCCAggCCQCoQtGQOJkzZTANBgkqhkiG9w0BAQsFADAOMQwwCgYDVQQDDANu
+            c2QwHhcNMTYxMTIxMDcxMjExWhcNMzYwODA4MDcxMjExWjAWMRQwEgYDVQQDDAtu
+            c2QtY29udHJvbDCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoCggGBAODDvjya
+            RKTO1sRGMjqZyX5izdmj4BSJs7XQ2ml+Dr5o+KauECgQGVB3WDtD6ao96C3kLaLk
+            HoCFqTJPPBvexPIcXqcXYXZO71k6pUZaEXxwxOHOv/WUUdBQI3TWA5uFmKA9GWN2
+            Vod4Q0zvNj5qEOSjJC/5UdzfcFiQ49XLEsFdHqIFadebRKqYgMUa1PGhtHffj6uL
+            bbBcmQ+sA8h0hiqgm1a6WXOpffIeBlQv0kFM2OH11Ae90UZyLvE/eiuXNgKzgUIU
+            vVbwQ8TknJm2UddVvxHi+oxyu3dfI78P1TDcFpjnVUMixBKUsoa7+c/WA0wY4PeD
+            GyJpuW8JR6TaBmj8d02XwtwknZ78x1eeUEOe5Cj07GIe7ZqhX14cKWDZU0sX6dL0
+            whV11IXOJX7DWT9DJnLlC/dqIPIRuBHDoVe4seF8Ny2/ba0yb7CCPZkC+fx6v0wg
+            jIk48OL+T/zhDxjcrhDBFMF+5XmB3qQneN3kVszgWqJFM1NGr7l9315qoQIDAQAB
+            MA0GCSqGSIb3DQEBCwUAA4IBgQAdfAmNlOzqBDnWGuNjn9+ySrV5lzqN1TXM/Q9a
+            F0mK9PYM8TKkLu7C/9voCyPCsvgilKh/inHkVMOW2jpiri6UtKIScKRvdEu3Pqle
+            6+q0ko339nKTvSje9evENF4mvSEOLU+L9p0HYUlyYHNb0e7Yvv9aV21kwC5nW+ll
+            d4dHlDO/t6eo2z9rlLgcNZEctiq+S0nvO8+S2De6GOiLP2o5Py5W7zmUjad9iQKi
+            L193FhQe+OgQ8lo+weMLpmY8d5beQlv3esN0s0Wo5Tu6E9g0n1Er4PPzlgdEL5oK
+            ZPWi0te97eroK3qEwotcf4ShIJ1JHy75YWir0mXrKGHAq4Ry5npi+tCKE0oMwPE7
+            shhhCHsyj4onseqOMSKQPZMCqsszV/UwMuPEUKnAPuwVnJeJVZ+86TzN3P+/C87p
+            UMNtyVWP+Eqtjhu3vpDXkuboH++Q00z4K+XLqGW0SK4iPWQMj+SU0FS7ZEK3AoTf
+            aIV491QzoOfbuVD5/n31wwAX/BU=
+            -----END CERTIFICATE-----
+        secret:
+          path: "{{ nsd_conf_dir_pre }}/nsd_control.key"
+          owner: "{% if ansible_os_family == 'OpenBSD' %}_nsd{% else %}nsd{% endif %}"
+          group: "{% if ansible_os_family == 'OpenBSD' %}_nsd{% else %}nsd{% endif %}"
+          mode: "0600"
+          key: |
+            -----BEGIN RSA PRIVATE KEY-----
+            MIIG5AIBAAKCAYEA4MO+PJpEpM7WxEYyOpnJfmLN2aPgFImztdDaaX4Ovmj4pq4Q
+            KBAZUHdYO0Ppqj3oLeQtouQegIWpMk88G97E8hxepxdhdk7vWTqlRloRfHDE4c6/
+            9ZRR0FAjdNYDm4WYoD0ZY3ZWh3hDTO82PmoQ5KMkL/lR3N9wWJDj1csSwV0eogVp
+            15tEqpiAxRrU8aG0d9+Pq4ttsFyZD6wDyHSGKqCbVrpZc6l98h4GVC/SQUzY4fXU
+            B73RRnIu8T96K5c2ArOBQhS9VvBDxOScmbZR11W/EeL6jHK7d18jvw/VMNwWmOdV
+            QyLEEpSyhrv5z9YDTBjg94MbImm5bwlHpNoGaPx3TZfC3CSdnvzHV55QQ57kKPTs
+            Yh7tmqFfXhwpYNlTSxfp0vTCFXXUhc4lfsNZP0MmcuUL92og8hG4EcOhV7ix4Xw3
+            Lb9trTJvsII9mQL5/Hq/TCCMiTjw4v5P/OEPGNyuEMEUwX7leYHepCd43eRWzOBa
+            okUzU0avuX3fXmqhAgMBAAECggGARrKLNfi4OrasqxQBXJle3Zgqc5iuNQeTNU86
+            RBBYht/xxkvd3RwjOkIvyIR2DQxn6XdqO2BRj897Bs4RdBrAC/+MbjZWe6Ycdw6R
+            Se2urluyMeycSJycl099t5RRkiuVdGGDiNuCIB5d3OcpQryOD7yY91YOv9CwP8tj
+            Pq4feh7WMdROFHlMQfSyHE1ySYa5gzMYt7ali+G0a0+J6RVt1h6qfb8jv9PCP9Pd
+            3cEk+1E2ruxqAv1bxDLKPSvgO7HVvk+gqIOHsmFBFYjKqw9rKXEgEw8+m5TKsFQe
+            iEiHsnBXHi8Nzh256DPzmI1C3xI+bfBFPhOH/rb1J20AIzGjIptzayvNZTFS9EUi
+            6xT4KFHSK18rFsisVPsHVZB3NnR/vSS8dRMGHu1b8c+uEx9cB4TZ09DHd8wq6yiB
+            kxtpPiSIUt3dxWmnZomIX2NNkkqHWVkn8ukyhbz2Gz16x4cqLeg9lWCS1rKW3ciB
+            61YkOYW39sx0TrhDQqz47MXe3QABAoHBAPce8nvWD4aDtEpsOEH57AbC0hJWXVz5
+            k2eHDrTHQZJJ+/ZT/0d4AaTsU1rJhV41iSwkUrTwMzZqNjCcJ2A7+Zw7bjOgMOu9
+            2r/eNVPiMHo1ZOVQtL9B9CC2NYeOzqztOd6nsnOtRmztyDBQADfcGlbIeM4as200
+            CIuQa5G1gmUrS4105MQXSGqy3fvXivjwY5o6kI+i3hI8e5z0KXEJuxzw4+YUGEDm
+            GGwJLiMjeCbW443xQcmCqHcdmjMPjSDioQKBwQDo1yjqAiwWzTwQdyXHZ3m/oZX9
+            fwgzLneAy4D0PUz4NXDdQ66jbN06l/TpH6QzxIW/GvCWXa2map0R8L7NpgsoUpU6
+            ERiSG/+hDKXVCrHQsJNxOftOd+WcTTfKFhM1hyHsJZWoW4lxmO1FxnlKz1AcDkVR
+            Z0cr27PqkrnD38UQ7m8ac/QDrmT9ibEKCYpLU2rxzhzaO2W0REPk58Z2W33yNFJO
+            RBHyNe2o3NAmHBNlos3rzDYj75kOLifodGLYiAECgcEA1bZg1DHSqW0bLUWb/YrK
+            0SoJDKy9/1sjXGQTlsm/bmknSudnnQIuwddTWu9utIOuBou/LxWP5J5EERPqhbI4
+            cyF+c4004ZsGI+piyhGSBQ5KHHsIZWL/Yo7RilM5b5mU83apwJp4jlmxR/7XwXdL
+            HAQxXWUACQ/31+Lk9FU52I5xv3r5IJBWI1he256TZChYqxe8z0t1q+W8rYcGk+hr
+            dmLpZJ+6Pd3//uaNjPvuvAAZOTcMwt2JHcJvCXuIfIkhAoHASYojTv2OpUj/DohD
+            M164MlE7yUvE8D1d2xzrRrjRxZdDZW8KCm3I1cfGv5aRyxPn1jsQ/7zoqqYDo/Xw
+            nY0y+vJSVXuu0f7r1xbijY4KKUqL1vgkKl1t9Nbipv4f5QkgKrCYOwtmNq3BSwdr
+            qbgeqi3LsPE4pl6GzbC34WicmkNkbetvh3YeSYGim/P1bOMU5PhfXoHiFnR1KSgX
+            I6yz87qYwEV5kZF81ZegWlkFu1UXSsE93E3BfpwPWLjhu1gBAoHBAIMvx1uhB8VR
+            iQVp1N3GqFCxactpOKo56xl05FmzIhcokQtdVnh+fErESZBQCy/jkT59MgOLWqhG
+            YK0NNRDWF0CKueKD/s/wxHJA3mxzWpcO+2i8pxn2ASQiCybx27KKaejGDFVs9SY5
+            MH+7k9pELBjDVMJZxQYwzYQFI9Rdl+LsTrLk5WL7VwD4D+Y86+S0ColCX5+QaAbO
+            OQ5B1CE6HXJkVbJd3SAvDD6Tghh82kaNmErU12lByNyv5Wzw0CC7aw==
+            -----END RSA PRIVATE KEY-----
+      - name: nsd_server
+        state: present
+        public:
+          path: "{{ nsd_conf_dir_pre }}/nsd_server.pem"
+          owner: "{% if ansible_os_family == 'OpenBSD' %}_nsd{% else %}nsd{% endif %}"
+          group: "{% if ansible_os_family == 'OpenBSD' %}_nsd{% else %}nsd{% endif %}"
+          mode: "0644"
+          key: |
+            -----BEGIN CERTIFICATE-----
+            MIIDmDCCAgACCQDDmVEHT/tH+TANBgkqhkiG9w0BAQsFADAOMQwwCgYDVQQDDANu
+            c2QwHhcNMTYxMTIxMDcxMjExWhcNMzYwODA4MDcxMjExWjAOMQwwCgYDVQQDDANu
+            c2QwggGiMA0GCSqGSIb3DQEBAQUAA4IBjwAwggGKAoIBgQCY+d//xS/ExsmMb17a
+            r+T/ANMYkzAjowVYEHjN9aixcJdvEFI7bLWSv93CgTlyBo+wyjVaCxLSmorfrqSh
+            h8v1ZYwgfpnY3I9+CSY8rAwxDTSaPkJELtjW25VKQXOmPh1MYshdOKTntNDq4td6
+            +ibYGiEPgUbSKqVYTEUg7M85iLHuMekMUrKFVWRHfe5G7Dbr3aO3w+BmLZY0ALN1
+            hqEQZQZj4o+cgPyJOaMGU/XyLZiizMk6Kaw8+IIvz4UJNgkAxrj/xkL/W/8EbFY7
+            lnoYLPxhLGYOElf369rwtfJ5btTKOLA4FLIqL2+UWaou4fkkJJdH9TKTY3nezD+H
+            hWGxHWpWdkCcrJMqUUx6zrxsLS367dNE4K++hKp5KvJhC0XeCBjWIw5BwwoqQjAk
+            y5j6o9wtkyXLMwE16R9xuCxIQp7Z5HoLIpzWUPlQcbWBqnyXzI8zD6i3YlGXDoDx
+            uYkbWeV4em+Exgdcbb5xodqJMZDLTxu7k5McS7DmZQaaw6kCAwEAATANBgkqhkiG
+            9w0BAQsFAAOCAYEAXydZ6k7jWJp+AmO8+g1mccSneRjYYE56z/lX/KnTRJ/pOsqu
+            5OPMlFk39NeOZETpNyXh1ydhbt4Vj+Ikj+mX3RCgcNvYgLMz7CRX8N4FVtXMlk7h
+            wbwjBZ3wTkoLZdpiJWF3g5ip90HtvuB3OdUyjZ3h5Sh2ti4evGBEEukCbitRXm5M
+            faPxSiGbcr7fIFnQYMfgDmq8V0Kt6uhfalESqIYHSWwzMqV/wdKWSnR+OKa8IBk/
+            7ekkssmDQu3/SYBpHXafiaP3MIYkLX+JekQxS0mi3IZDMh8GKFoHXMR6qEIPHiXV
+            kueb0yPHYJjkXmqEOQ1JHSOFbdbYqZ2u4nPed4FlwnF2SEauBvyiz9ZwC8w5uSE+
+            woLsoxMcyQieG2UGNaLkOXYzO4JGLEex1RpcRmJpgmVyLrsYHHfgtUm8pPk/xope
+            POj3pD01n2CUfGAmY7ZE6METwXNSGbmgpa1I782bwlqsObfjAtt9JG78OdLNvIW9
+            N49rbR5hkqy9SVm7
+            -----END CERTIFICATE-----
+        secret:
+          path: "{{ nsd_conf_dir_pre }}/nsd_server.key"
+          owner: "{% if ansible_os_family == 'OpenBSD' %}_nsd{% else %}nsd{% endif %}"
+          group: "{% if ansible_os_family == 'OpenBSD' %}_nsd{% else %}nsd{% endif %}"
+          mode: "0600"
+          key: |
+            -----BEGIN RSA PRIVATE KEY-----
+            MIIG4wIBAAKCAYEAmPnf/8UvxMbJjG9e2q/k/wDTGJMwI6MFWBB4zfWosXCXbxBS
+            O2y1kr/dwoE5cgaPsMo1WgsS0pqK366koYfL9WWMIH6Z2NyPfgkmPKwMMQ00mj5C
+            RC7Y1tuVSkFzpj4dTGLIXTik57TQ6uLXevom2BohD4FG0iqlWExFIOzPOYix7jHp
+            DFKyhVVkR33uRuw2692jt8PgZi2WNACzdYahEGUGY+KPnID8iTmjBlP18i2YoszJ
+            OimsPPiCL8+FCTYJAMa4/8ZC/1v/BGxWO5Z6GCz8YSxmDhJX9+va8LXyeW7Uyjiw
+            OBSyKi9vlFmqLuH5JCSXR/Uyk2N53sw/h4VhsR1qVnZAnKyTKlFMes68bC0t+u3T
+            ROCvvoSqeSryYQtF3ggY1iMOQcMKKkIwJMuY+qPcLZMlyzMBNekfcbgsSEKe2eR6
+            CyKc1lD5UHG1gap8l8yPMw+ot2JRlw6A8bmJG1nleHpvhMYHXG2+caHaiTGQy08b
+            u5OTHEuw5mUGmsOpAgMBAAECggGAOExloqS4QswB6twl5YesWCi+h6HLqqHZWqKd
+            QvcwwTS1lptEGDiWzk4sV+Pk91Dw2thgMCY5JCbaCx4j2oq2hjZ8Do1pI0Vwzaqi
+            VtvelMLOZCGbk6pGBTTEyZIy9LCRacZFBQHOtrN126vmL40WdJuRJTqnjLtDJK7V
+            Fhvw27Sx/v6BTRa2OpnFkQYIhjNytvVXxk6hLBmE2NiVMyB78COt6V69CZTy27HJ
+            jI+jyR/8t5V0TSJ/D+VJTD0sMcqfjelrpQBIfcr3tVuJ41BKGEDbomV7rWKhbWEx
+            f5tLxAupB9so6PULWaUtWpvE5s/Mw8cpb2GhT/hUlpUxtlTwv0//CtHaYFOjqaCY
+            W6+KJ9hDoaUfuCn/423xjkjP9PTPYMZvPNOcd/6l711oaNwJW0XV5vBXrxX9XSpp
+            C2NbaWdT41/l0qQy4sR8DGXC7DBd18SmJ6ta1WU4DPDR7fqhCDTHSvp7+Y8XII2W
+            LOLRU1XVf0OVl74i7rahjsOF5oAdAoHBAMmD43/1/DQBeeHTgxgN/I68qx32byrV
+            uDz+hPkRZWXIsRxZMjGOihX4gaTu1u/EUCdwXdf4EwsGyec7PyBjX2PrlLUJvvrD
+            X1vhprNaksGk36wqNd+omUMk6OlCzg7UBjpBd+Zn2Sitc5LHPpGS1UNPzQgnp8PR
+            ddxeRf72yCLQGG2fdW1XU1hyuIMIEP3ujjOYGXslh7jImfnwC3Cs8G7W97T/6Sn6
+            Yr8WjxaAlo6yfHh3VWe+a0CChVbl7MFrcwKBwQDCVktSPNeh+aapVDaHvQlBGsT8
+            FbqRyAqU4/GU91ucmO9IZpnSiXcCHK5RI7Hxs0JE2TDYTYcb06IK2ARYf/FAsa1E
+            b3R60bweohB9W7Wutb1SJFjpGfxgoOJN1JwHW4NiCNbB6X36aJSFl4pO6mjNuND+
+            JTXLtl3w9vN/TAX1uAMZPP3hoNCQ+DIf2pq9VVtX1Zel6xmcHLtxl5kwzResLzXm
+            MFq7AtQonvsxjgk0+mJrsIEZZ70wZRvWQmnYxXMCgcEAoSk+f6795aWskUO0Wz+M
+            Vadj/tGAtLQ55WX0eLFF87IemzpmnyWNH+cf4AU3lofdRr1iAAAhUrc6MBi88q0m
+            s+XLh0HlH+2yTOxZgqUUK5QtYiZb8aSH9iAFuc+4tjkxRdPoDTfOf+7AOInqa0gQ
+            EQY4RqZYUI4rAXPP7Qn2o4jjkIBvzGODf4A4OmrwE/V+eprQ/iDUu56LLk2hCJr2
+            qt53OqVUF0NtR7/F7cwnHLZ4P2vIvPCYG/6GnynBQCsrAoHAMyL77ObfotqLdVEY
+            jD082ynNHbwl/MhTqHwWjKlOLPW9OSLuZQ0RCLg9UlJ/N2eBD5bLGI/F9peIsyvG
+            cPcxp2FZg4GEd/EKfFEO372rIA7og13XG3dgBpkvE2XXrMPy3XAP+rSTFrpAIqsO
+            lNdvvnpcXBO0hSc2rvp8dkmt48uI3TJEaAOl/g+hOOqP/zQftgwZPGqRsZeJ50kJ
+            4WKGUSOXHjwpE76ZzxqOZKrIV21vSoEGZ4X5rWtdmNKfAZBrAoHAWlHbAPvxFbE/
+            m4EDkWDYPIGShoszU6dwmdD4dbMhcwRfV8DlwlGrQG1AR5cB4UW+himuPxIjphe8
+            xwnTOZTkbMw8pFpTSqjdr5F6/Jb0TYPM1aKkwIPvNSO3fIAetlNJ0Utjxc5E+j3h
+            wcwBs9lXh+0LaOfO+ZamaaEU8PSF9B+x2YerGApkngnFyskajoRF0Vvi4kfQJ6XO
+            Ghu89wCSP7UzhSpeLdtno3MFIaiEPpJo81q3Z/ELEWKHUiIwa0gg
+            -----END RSA PRIVATE KEY-----
     nsd_keys:
       my_tsig_key:
         secret: Qes2X7V8Fjg+EMlqng1qlCvErGFxXWa4Gxfy1uDWKvQ=
@@ -10,132 +167,6 @@
     nsd_conf_control_enable: "yes"
     nsd_remote_enable: true
     nsd_remote_setup: false
-    nsd_conf_server_cert: |
-      -----BEGIN CERTIFICATE-----
-      MIIDmDCCAgACCQDDmVEHT/tH+TANBgkqhkiG9w0BAQsFADAOMQwwCgYDVQQDDANu
-      c2QwHhcNMTYxMTIxMDcxMjExWhcNMzYwODA4MDcxMjExWjAOMQwwCgYDVQQDDANu
-      c2QwggGiMA0GCSqGSIb3DQEBAQUAA4IBjwAwggGKAoIBgQCY+d//xS/ExsmMb17a
-      r+T/ANMYkzAjowVYEHjN9aixcJdvEFI7bLWSv93CgTlyBo+wyjVaCxLSmorfrqSh
-      h8v1ZYwgfpnY3I9+CSY8rAwxDTSaPkJELtjW25VKQXOmPh1MYshdOKTntNDq4td6
-      +ibYGiEPgUbSKqVYTEUg7M85iLHuMekMUrKFVWRHfe5G7Dbr3aO3w+BmLZY0ALN1
-      hqEQZQZj4o+cgPyJOaMGU/XyLZiizMk6Kaw8+IIvz4UJNgkAxrj/xkL/W/8EbFY7
-      lnoYLPxhLGYOElf369rwtfJ5btTKOLA4FLIqL2+UWaou4fkkJJdH9TKTY3nezD+H
-      hWGxHWpWdkCcrJMqUUx6zrxsLS367dNE4K++hKp5KvJhC0XeCBjWIw5BwwoqQjAk
-      y5j6o9wtkyXLMwE16R9xuCxIQp7Z5HoLIpzWUPlQcbWBqnyXzI8zD6i3YlGXDoDx
-      uYkbWeV4em+Exgdcbb5xodqJMZDLTxu7k5McS7DmZQaaw6kCAwEAATANBgkqhkiG
-      9w0BAQsFAAOCAYEAXydZ6k7jWJp+AmO8+g1mccSneRjYYE56z/lX/KnTRJ/pOsqu
-      5OPMlFk39NeOZETpNyXh1ydhbt4Vj+Ikj+mX3RCgcNvYgLMz7CRX8N4FVtXMlk7h
-      wbwjBZ3wTkoLZdpiJWF3g5ip90HtvuB3OdUyjZ3h5Sh2ti4evGBEEukCbitRXm5M
-      faPxSiGbcr7fIFnQYMfgDmq8V0Kt6uhfalESqIYHSWwzMqV/wdKWSnR+OKa8IBk/
-      7ekkssmDQu3/SYBpHXafiaP3MIYkLX+JekQxS0mi3IZDMh8GKFoHXMR6qEIPHiXV
-      kueb0yPHYJjkXmqEOQ1JHSOFbdbYqZ2u4nPed4FlwnF2SEauBvyiz9ZwC8w5uSE+
-      woLsoxMcyQieG2UGNaLkOXYzO4JGLEex1RpcRmJpgmVyLrsYHHfgtUm8pPk/xope
-      POj3pD01n2CUfGAmY7ZE6METwXNSGbmgpa1I782bwlqsObfjAtt9JG78OdLNvIW9
-      N49rbR5hkqy9SVm7
-      -----END CERTIFICATE-----
-    nsd_conf_server_key: |
-      -----BEGIN RSA PRIVATE KEY-----
-      MIIG4wIBAAKCAYEAmPnf/8UvxMbJjG9e2q/k/wDTGJMwI6MFWBB4zfWosXCXbxBS
-      O2y1kr/dwoE5cgaPsMo1WgsS0pqK366koYfL9WWMIH6Z2NyPfgkmPKwMMQ00mj5C
-      RC7Y1tuVSkFzpj4dTGLIXTik57TQ6uLXevom2BohD4FG0iqlWExFIOzPOYix7jHp
-      DFKyhVVkR33uRuw2692jt8PgZi2WNACzdYahEGUGY+KPnID8iTmjBlP18i2YoszJ
-      OimsPPiCL8+FCTYJAMa4/8ZC/1v/BGxWO5Z6GCz8YSxmDhJX9+va8LXyeW7Uyjiw
-      OBSyKi9vlFmqLuH5JCSXR/Uyk2N53sw/h4VhsR1qVnZAnKyTKlFMes68bC0t+u3T
-      ROCvvoSqeSryYQtF3ggY1iMOQcMKKkIwJMuY+qPcLZMlyzMBNekfcbgsSEKe2eR6
-      CyKc1lD5UHG1gap8l8yPMw+ot2JRlw6A8bmJG1nleHpvhMYHXG2+caHaiTGQy08b
-      u5OTHEuw5mUGmsOpAgMBAAECggGAOExloqS4QswB6twl5YesWCi+h6HLqqHZWqKd
-      QvcwwTS1lptEGDiWzk4sV+Pk91Dw2thgMCY5JCbaCx4j2oq2hjZ8Do1pI0Vwzaqi
-      VtvelMLOZCGbk6pGBTTEyZIy9LCRacZFBQHOtrN126vmL40WdJuRJTqnjLtDJK7V
-      Fhvw27Sx/v6BTRa2OpnFkQYIhjNytvVXxk6hLBmE2NiVMyB78COt6V69CZTy27HJ
-      jI+jyR/8t5V0TSJ/D+VJTD0sMcqfjelrpQBIfcr3tVuJ41BKGEDbomV7rWKhbWEx
-      f5tLxAupB9so6PULWaUtWpvE5s/Mw8cpb2GhT/hUlpUxtlTwv0//CtHaYFOjqaCY
-      W6+KJ9hDoaUfuCn/423xjkjP9PTPYMZvPNOcd/6l711oaNwJW0XV5vBXrxX9XSpp
-      C2NbaWdT41/l0qQy4sR8DGXC7DBd18SmJ6ta1WU4DPDR7fqhCDTHSvp7+Y8XII2W
-      LOLRU1XVf0OVl74i7rahjsOF5oAdAoHBAMmD43/1/DQBeeHTgxgN/I68qx32byrV
-      uDz+hPkRZWXIsRxZMjGOihX4gaTu1u/EUCdwXdf4EwsGyec7PyBjX2PrlLUJvvrD
-      X1vhprNaksGk36wqNd+omUMk6OlCzg7UBjpBd+Zn2Sitc5LHPpGS1UNPzQgnp8PR
-      ddxeRf72yCLQGG2fdW1XU1hyuIMIEP3ujjOYGXslh7jImfnwC3Cs8G7W97T/6Sn6
-      Yr8WjxaAlo6yfHh3VWe+a0CChVbl7MFrcwKBwQDCVktSPNeh+aapVDaHvQlBGsT8
-      FbqRyAqU4/GU91ucmO9IZpnSiXcCHK5RI7Hxs0JE2TDYTYcb06IK2ARYf/FAsa1E
-      b3R60bweohB9W7Wutb1SJFjpGfxgoOJN1JwHW4NiCNbB6X36aJSFl4pO6mjNuND+
-      JTXLtl3w9vN/TAX1uAMZPP3hoNCQ+DIf2pq9VVtX1Zel6xmcHLtxl5kwzResLzXm
-      MFq7AtQonvsxjgk0+mJrsIEZZ70wZRvWQmnYxXMCgcEAoSk+f6795aWskUO0Wz+M
-      Vadj/tGAtLQ55WX0eLFF87IemzpmnyWNH+cf4AU3lofdRr1iAAAhUrc6MBi88q0m
-      s+XLh0HlH+2yTOxZgqUUK5QtYiZb8aSH9iAFuc+4tjkxRdPoDTfOf+7AOInqa0gQ
-      EQY4RqZYUI4rAXPP7Qn2o4jjkIBvzGODf4A4OmrwE/V+eprQ/iDUu56LLk2hCJr2
-      qt53OqVUF0NtR7/F7cwnHLZ4P2vIvPCYG/6GnynBQCsrAoHAMyL77ObfotqLdVEY
-      jD082ynNHbwl/MhTqHwWjKlOLPW9OSLuZQ0RCLg9UlJ/N2eBD5bLGI/F9peIsyvG
-      cPcxp2FZg4GEd/EKfFEO372rIA7og13XG3dgBpkvE2XXrMPy3XAP+rSTFrpAIqsO
-      lNdvvnpcXBO0hSc2rvp8dkmt48uI3TJEaAOl/g+hOOqP/zQftgwZPGqRsZeJ50kJ
-      4WKGUSOXHjwpE76ZzxqOZKrIV21vSoEGZ4X5rWtdmNKfAZBrAoHAWlHbAPvxFbE/
-      m4EDkWDYPIGShoszU6dwmdD4dbMhcwRfV8DlwlGrQG1AR5cB4UW+himuPxIjphe8
-      xwnTOZTkbMw8pFpTSqjdr5F6/Jb0TYPM1aKkwIPvNSO3fIAetlNJ0Utjxc5E+j3h
-      wcwBs9lXh+0LaOfO+ZamaaEU8PSF9B+x2YerGApkngnFyskajoRF0Vvi4kfQJ6XO
-      Ghu89wCSP7UzhSpeLdtno3MFIaiEPpJo81q3Z/ELEWKHUiIwa0gg
-      -----END RSA PRIVATE KEY-----
-    nsd_conf_control_cert: |
-      -----BEGIN CERTIFICATE-----
-      MIIDoDCCAggCCQCoQtGQOJkzZTANBgkqhkiG9w0BAQsFADAOMQwwCgYDVQQDDANu
-      c2QwHhcNMTYxMTIxMDcxMjExWhcNMzYwODA4MDcxMjExWjAWMRQwEgYDVQQDDAtu
-      c2QtY29udHJvbDCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoCggGBAODDvjya
-      RKTO1sRGMjqZyX5izdmj4BSJs7XQ2ml+Dr5o+KauECgQGVB3WDtD6ao96C3kLaLk
-      HoCFqTJPPBvexPIcXqcXYXZO71k6pUZaEXxwxOHOv/WUUdBQI3TWA5uFmKA9GWN2
-      Vod4Q0zvNj5qEOSjJC/5UdzfcFiQ49XLEsFdHqIFadebRKqYgMUa1PGhtHffj6uL
-      bbBcmQ+sA8h0hiqgm1a6WXOpffIeBlQv0kFM2OH11Ae90UZyLvE/eiuXNgKzgUIU
-      vVbwQ8TknJm2UddVvxHi+oxyu3dfI78P1TDcFpjnVUMixBKUsoa7+c/WA0wY4PeD
-      GyJpuW8JR6TaBmj8d02XwtwknZ78x1eeUEOe5Cj07GIe7ZqhX14cKWDZU0sX6dL0
-      whV11IXOJX7DWT9DJnLlC/dqIPIRuBHDoVe4seF8Ny2/ba0yb7CCPZkC+fx6v0wg
-      jIk48OL+T/zhDxjcrhDBFMF+5XmB3qQneN3kVszgWqJFM1NGr7l9315qoQIDAQAB
-      MA0GCSqGSIb3DQEBCwUAA4IBgQAdfAmNlOzqBDnWGuNjn9+ySrV5lzqN1TXM/Q9a
-      F0mK9PYM8TKkLu7C/9voCyPCsvgilKh/inHkVMOW2jpiri6UtKIScKRvdEu3Pqle
-      6+q0ko339nKTvSje9evENF4mvSEOLU+L9p0HYUlyYHNb0e7Yvv9aV21kwC5nW+ll
-      d4dHlDO/t6eo2z9rlLgcNZEctiq+S0nvO8+S2De6GOiLP2o5Py5W7zmUjad9iQKi
-      L193FhQe+OgQ8lo+weMLpmY8d5beQlv3esN0s0Wo5Tu6E9g0n1Er4PPzlgdEL5oK
-      ZPWi0te97eroK3qEwotcf4ShIJ1JHy75YWir0mXrKGHAq4Ry5npi+tCKE0oMwPE7
-      shhhCHsyj4onseqOMSKQPZMCqsszV/UwMuPEUKnAPuwVnJeJVZ+86TzN3P+/C87p
-      UMNtyVWP+Eqtjhu3vpDXkuboH++Q00z4K+XLqGW0SK4iPWQMj+SU0FS7ZEK3AoTf
-      aIV491QzoOfbuVD5/n31wwAX/BU=
-      -----END CERTIFICATE-----
-    nsd_conf_control_key: |
-      -----BEGIN RSA PRIVATE KEY-----
-      MIIG5AIBAAKCAYEA4MO+PJpEpM7WxEYyOpnJfmLN2aPgFImztdDaaX4Ovmj4pq4Q
-      KBAZUHdYO0Ppqj3oLeQtouQegIWpMk88G97E8hxepxdhdk7vWTqlRloRfHDE4c6/
-      9ZRR0FAjdNYDm4WYoD0ZY3ZWh3hDTO82PmoQ5KMkL/lR3N9wWJDj1csSwV0eogVp
-      15tEqpiAxRrU8aG0d9+Pq4ttsFyZD6wDyHSGKqCbVrpZc6l98h4GVC/SQUzY4fXU
-      B73RRnIu8T96K5c2ArOBQhS9VvBDxOScmbZR11W/EeL6jHK7d18jvw/VMNwWmOdV
-      QyLEEpSyhrv5z9YDTBjg94MbImm5bwlHpNoGaPx3TZfC3CSdnvzHV55QQ57kKPTs
-      Yh7tmqFfXhwpYNlTSxfp0vTCFXXUhc4lfsNZP0MmcuUL92og8hG4EcOhV7ix4Xw3
-      Lb9trTJvsII9mQL5/Hq/TCCMiTjw4v5P/OEPGNyuEMEUwX7leYHepCd43eRWzOBa
-      okUzU0avuX3fXmqhAgMBAAECggGARrKLNfi4OrasqxQBXJle3Zgqc5iuNQeTNU86
-      RBBYht/xxkvd3RwjOkIvyIR2DQxn6XdqO2BRj897Bs4RdBrAC/+MbjZWe6Ycdw6R
-      Se2urluyMeycSJycl099t5RRkiuVdGGDiNuCIB5d3OcpQryOD7yY91YOv9CwP8tj
-      Pq4feh7WMdROFHlMQfSyHE1ySYa5gzMYt7ali+G0a0+J6RVt1h6qfb8jv9PCP9Pd
-      3cEk+1E2ruxqAv1bxDLKPSvgO7HVvk+gqIOHsmFBFYjKqw9rKXEgEw8+m5TKsFQe
-      iEiHsnBXHi8Nzh256DPzmI1C3xI+bfBFPhOH/rb1J20AIzGjIptzayvNZTFS9EUi
-      6xT4KFHSK18rFsisVPsHVZB3NnR/vSS8dRMGHu1b8c+uEx9cB4TZ09DHd8wq6yiB
-      kxtpPiSIUt3dxWmnZomIX2NNkkqHWVkn8ukyhbz2Gz16x4cqLeg9lWCS1rKW3ciB
-      61YkOYW39sx0TrhDQqz47MXe3QABAoHBAPce8nvWD4aDtEpsOEH57AbC0hJWXVz5
-      k2eHDrTHQZJJ+/ZT/0d4AaTsU1rJhV41iSwkUrTwMzZqNjCcJ2A7+Zw7bjOgMOu9
-      2r/eNVPiMHo1ZOVQtL9B9CC2NYeOzqztOd6nsnOtRmztyDBQADfcGlbIeM4as200
-      CIuQa5G1gmUrS4105MQXSGqy3fvXivjwY5o6kI+i3hI8e5z0KXEJuxzw4+YUGEDm
-      GGwJLiMjeCbW443xQcmCqHcdmjMPjSDioQKBwQDo1yjqAiwWzTwQdyXHZ3m/oZX9
-      fwgzLneAy4D0PUz4NXDdQ66jbN06l/TpH6QzxIW/GvCWXa2map0R8L7NpgsoUpU6
-      ERiSG/+hDKXVCrHQsJNxOftOd+WcTTfKFhM1hyHsJZWoW4lxmO1FxnlKz1AcDkVR
-      Z0cr27PqkrnD38UQ7m8ac/QDrmT9ibEKCYpLU2rxzhzaO2W0REPk58Z2W33yNFJO
-      RBHyNe2o3NAmHBNlos3rzDYj75kOLifodGLYiAECgcEA1bZg1DHSqW0bLUWb/YrK
-      0SoJDKy9/1sjXGQTlsm/bmknSudnnQIuwddTWu9utIOuBou/LxWP5J5EERPqhbI4
-      cyF+c4004ZsGI+piyhGSBQ5KHHsIZWL/Yo7RilM5b5mU83apwJp4jlmxR/7XwXdL
-      HAQxXWUACQ/31+Lk9FU52I5xv3r5IJBWI1he256TZChYqxe8z0t1q+W8rYcGk+hr
-      dmLpZJ+6Pd3//uaNjPvuvAAZOTcMwt2JHcJvCXuIfIkhAoHASYojTv2OpUj/DohD
-      M164MlE7yUvE8D1d2xzrRrjRxZdDZW8KCm3I1cfGv5aRyxPn1jsQ/7zoqqYDo/Xw
-      nY0y+vJSVXuu0f7r1xbijY4KKUqL1vgkKl1t9Nbipv4f5QkgKrCYOwtmNq3BSwdr
-      qbgeqi3LsPE4pl6GzbC34WicmkNkbetvh3YeSYGim/P1bOMU5PhfXoHiFnR1KSgX
-      I6yz87qYwEV5kZF81ZegWlkFu1UXSsE93E3BfpwPWLjhu1gBAoHBAIMvx1uhB8VR
-      iQVp1N3GqFCxactpOKo56xl05FmzIhcokQtdVnh+fErESZBQCy/jkT59MgOLWqhG
-      YK0NNRDWF0CKueKD/s/wxHJA3mxzWpcO+2i8pxn2ASQiCybx27KKaejGDFVs9SY5
-      MH+7k9pELBjDVMJZxQYwzYQFI9Rdl+LsTrLk5WL7VwD4D+Y86+S0ColCX5+QaAbO
-      OQ5B1CE6HXJkVbJd3SAvDD6Tghh82kaNmErU12lByNyv5Wzw0CC7aw==
-      -----END RSA PRIVATE KEY-----
     nsd_config_server: []
     nsd_config_remote:
       - "control-enable: yes"

--- a/tests/serverspec/remote_control_with_variables.yml
+++ b/tests/serverspec/remote_control_with_variables.yml
@@ -168,7 +168,7 @@
     nsd_remote_enable: true
     nsd_remote_setup: false
     nsd_config_server: []
-    nsd_config_remote:
+    nsd_config_remote_control:
       - "control-enable: yes"
       - "control-interface: 127.0.0.1"
       - "control-port: 8952"

--- a/tests/serverspec/remote_control_with_variables.yml
+++ b/tests/serverspec/remote_control_with_variables.yml
@@ -136,10 +136,32 @@
       MH+7k9pELBjDVMJZxQYwzYQFI9Rdl+LsTrLk5WL7VwD4D+Y86+S0ColCX5+QaAbO
       OQ5B1CE6HXJkVbJd3SAvDD6Tghh82kaNmErU12lByNyv5Wzw0CC7aw==
       -----END RSA PRIVATE KEY-----
+    nsd_config_server: []
+    nsd_config_remote:
+      - "control-enable: yes"
+      - "control-interface: 127.0.0.1"
+      - "control-port: 8952"
+      - name: server-key-file
+        value: '"/etc/nsd/nsd_server.key"'
+      - name: server-cert-file
+        value: '"/etc/nsd/nsd_server.pem"'
+      - name: control-key-file
+        value: '"/etc/nsd/nsd_control.key"'
+      - name: control-cert-file
+        value: '"/etc/nsd/nsd_control.pem"'
     nsd_zones:
       example.com:
-        request_xfr:
-          - 192.168.133.100 my_tsig_key
+        zonefile: example.com.zone
+        zone: |
+          example.com. 86400 IN SOA ns1.example.com. hostmaster.example.com. 2013020201 10800 3600 604800 3600
+          example.com. 86400 IN NS ns1.example.com.
+          example.com. 120 IN A 192.168.0.1
+          ns1.example.com. 120 IN A 192.168.0.1
+          mail.example.com. 120 IN A 192.168.0.1
+          example.com. 120 IN MX 25 mail.example.com.
+        config:
+          - name: request-xfr
+            value: 192.168.133.100 my_tsig_key
 
     redhat_repo_extra_packages:
       - epel-release

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,4 +3,4 @@ __nsd_group: nsd
 __nsd_db_dir: /var/lib/nsd
 __nsd_conf_dir: /etc/nsd
 __nsd_run_dir: /var/run/nsd
-__nsd_state_dir: "{{ __nsd_db_dir }}"
+__nsd_state_dir: "{{ nsd_db_dir }}"

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -3,4 +3,4 @@ __nsd_group: nsd
 __nsd_db_dir: /var/db/nsd
 __nsd_conf_dir: /usr/local/etc/nsd
 __nsd_run_dir: /var/run/nsd
-__nsd_state_dir: "{{ __nsd_db_dir }}"
+__nsd_state_dir: "{{ nsd_db_dir }}"

--- a/vars/OpenBSD.yml
+++ b/vars/OpenBSD.yml
@@ -3,4 +3,4 @@ __nsd_group: _nsd
 __nsd_db_dir: /var/nsd/db
 __nsd_conf_dir: /var/nsd/etc
 __nsd_run_dir: /var/nsd/run
-__nsd_state_dir: "{{ __nsd_run_dir }}"
+__nsd_state_dir: "{{ nsd_run_dir }}"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -3,4 +3,4 @@ __nsd_group: nsd
 __nsd_db_dir: /var/lib/nsd
 __nsd_conf_dir: /etc/nsd
 __nsd_run_dir: /var/run/nsd
-__nsd_state_dir: "{{ __nsd_db_dir }}"
+__nsd_state_dir: "{{ nsd_db_dir }}"


### PR DESCRIPTION
This PR introduces `nsd_config_server` and `nsd_config_remote_control` that
supports arbitrary user configurations, like `ansible-role-unbound`.

* fixes #31 

more cleanups will follow