### PR TITLE
[feature] introduce `nsd_include_role_x509_certificate`

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -125,4 +125,3 @@ suites:
       command: rspec -c -f d -I tests/serverspec tests/serverspec/remote_control_with_variables_spec.rb
     includes:
       - centos-7.3-x86_64
-      - freebsd-10.3-amd64

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -97,6 +97,8 @@ suites:
       command: rspec -c -f d -I tests/serverspec tests/serverspec/remote_control_spec.rb
 
   - name: remote_control_with_variables
+    # XXX this suite is deprecated and if a platform _properly_ supports
+    # `include_role`, the platform should run `x509` test suite instead.
     provisioner:
       name: ansible_playbook
       playbook: tests/serverspec/remote_control_with_variables.yml
@@ -106,6 +108,21 @@ suites:
     verifier:
       name: shell
       command: rspec -c -f d -I tests/serverspec tests/serverspec/remote_control_with_variables_spec.rb
-    # as this test case is platform-independant, running on a single platform
-    # is enough.
-    includes: centos-7.3-x86_64
+    excludes:
+      - centos-7.3-x86_64
+
+  - name: x509
+    # XXX to run this suite, ansible must be >= 2.2 _and_ bugs in
+    # `include_role` must be fixed.
+    provisioner:
+      name: ansible_playbook
+      playbook: tests/serverspec/x509.yml
+    driver:
+      network:
+      -  ["private_network", {ip: "192.168.133.101/24"}]
+    verifier:
+      name: shell
+      command: rspec -c -f d -I tests/serverspec tests/serverspec/remote_control_with_variables_spec.rb
+    includes:
+      - centos-7.3-x86_64
+      - freebsd-10.3-amd64

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ it, other platforms do not require it.
 | `nsd_flags` | (not implemented) | `""` |
 | `nsd_remote_setup` | run `nsd-control-setup` to create self-signed keys. when false, you need to provide certificates and keys (use `reallyenglish.x509-certificate` and see an example in `tests/serverspec/remote_control_with_variables.yml` | `false` |
 | `nsd_zones` | dict of zones (see below) | `{}` |
+| `nsd_x509_certificate_enable` | include and execute `reallyenglish.x509-certificate` during the play if `yes` (see below) | `no` |
 
 ## `nsd_config_server`
 
@@ -132,6 +133,28 @@ nsd_zones:
           - 192.168.0.1
       - 'allow-axfr-fallback: yes'
 ```
+
+## `nsd_x509_certificate_enable`
+
+When `yes`, this variable includes and execute
+[`reallyenglish.x509`](https://github.com/reallyenglish/ansible-role-x509-certificate)
+during the play, which makes it possible to manage certificates without ugly
+hacks. This is only supported in `ansible` version _at least_ 2.2 and later
+(but see also issue #34 for possible bugs).
+
+Confirmed to work:
+
+| platform | `ansible version` |
+|----------|-------------------|
+| CentOS   | 2.3.1.0           |
+
+See an example in
+[tests/serverspec/x509.yml](https://github.com/reallyenglish/ansible-role-nsd/tree/master/tests/serverspec/x509.yml).
+
+If `ansible` version requirement cannot be met or your `ansible` version does
+not work with `nsd_x509_certificate_enable`, you need some hacks. See an
+example in
+[tests/serverspec/remote_control_with_variables.yml](https://github.com/reallyenglish/ansible-role-nsd/tree/master/tests/serverspec/remote_control_with_variables.yml).
 
 ## Debian
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ it, other platforms do not require it.
 | `nsd_flags` | (not implemented) | `""` |
 | `nsd_remote_setup` | run `nsd-control-setup` to create self-signed keys. when false, you need to provide certificates and keys (use `reallyenglish.x509-certificate` and see an example in `tests/serverspec/remote_control_with_variables.yml` | `false` |
 | `nsd_zones` | dict of zones (see below) | `{}` |
-| `nsd_x509_certificate_enable` | include and execute `reallyenglish.x509-certificate` during the play if `yes` (see below) | `no` |
+| `nsd_include_role_x509_certificate` | include and execute `reallyenglish.x509-certificate` during the play if `yes` (see below) | `no` |
 
 ## `nsd_config_server`
 
@@ -134,7 +134,7 @@ nsd_zones:
       - 'allow-axfr-fallback: yes'
 ```
 
-## `nsd_x509_certificate_enable`
+## `nsd_include_role_x509_certificate`
 
 When `yes`, this variable includes and execute
 [`reallyenglish.x509`](https://github.com/reallyenglish/ansible-role-x509-certificate)
@@ -152,7 +152,7 @@ See an example in
 [tests/serverspec/x509.yml](https://github.com/reallyenglish/ansible-role-nsd/tree/master/tests/serverspec/x509.yml).
 
 If `ansible` version requirement cannot be met or your `ansible` version does
-not work with `nsd_x509_certificate_enable`, you need some hacks. See an
+not work with `nsd_include_role_x509_certificate`, you need some hacks. See an
 example in
 [tests/serverspec/remote_control_with_variables.yml](https://github.com/reallyenglish/ansible-role-nsd/tree/master/tests/serverspec/remote_control_with_variables.yml).
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,4 +12,4 @@ nsd_flags: ""
 nsd_remote_setup: false
 # master and slave
 nsd_zones: {}
-nsd_x509_certificate_enable: no
+nsd_include_role_x509_certificate: no

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,4 @@ nsd_flags: ""
 nsd_remote_setup: false
 # master and slave
 nsd_zones: {}
+nsd_x509_certificate_enable: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
 - include: "x509.yml"
   when:
     - ansible_version.full | version_compare('2.2', '>=')
-    - nsd_x509_certificate_enable
+    - nsd_include_role_x509_certificate
 
 - name: Create db directory
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,11 @@
 
 - include: "install-{{ ansible_os_family }}.yml"
 
+- include: "x509.yml"
+  when:
+    - ansible_version.full | version_compare('2.2', '>=')
+    - nsd_x509_certificate_enable
+
 - name: Create db directory
   file:
     path: "{{ nsd_db_dir }}"

--- a/tasks/x509.yml
+++ b/tasks/x509.yml
@@ -5,4 +5,4 @@
 - name: Include x509-certificate
   include_role:
     name: reallyenglish.x509-certificate
-  when: nsd_x509_certificate_enable
+  when: nsd_include_role_x509_certificate

--- a/tasks/x509.yml
+++ b/tasks/x509.yml
@@ -1,0 +1,8 @@
+---
+
+# XXX this task should have been in `tasks/main.yml` but ansible older than 2.2
+# does not understand `include_role` and bails out.
+- name: Include x509-certificate
+  include_role:
+    name: reallyenglish.x509-certificate
+  when: nsd_x509_certificate_enable

--- a/tests/serverspec/x509.yml
+++ b/tests/serverspec/x509.yml
@@ -3,7 +3,7 @@
     - reallyenglish.redhat-repo
     - ansible-role-nsd
   vars:
-    nsd_x509_certificate_enable: yes
+    nsd_include_role_x509_certificate: yes
 
     # XXX NEVER set this to yes in production
     x509_certificate_debug_log: yes

--- a/tests/serverspec/x509.yml
+++ b/tests/serverspec/x509.yml
@@ -1,21 +1,19 @@
 - hosts: localhost
   roles:
     - reallyenglish.redhat-repo
-    - reallyenglish.x509-certificate
     - ansible-role-nsd
   vars:
-    x509_certificate_additional_packages: "{% if ansible_os_family == 'OpenBSD' %}[]{% else %}nsd{% endif %}"
-    # XXX nsd_conf_dir_pre == nsd_conf_dir
-    # when x509-certificate is applied to the host, `nsd_conf_dir` is not
-    # included yet.
-    nsd_conf_dir_pre: "{% if ansible_os_family == 'OpenBSD' %}/var/nsd/etc{% elif ansible_os_family == 'FreeBSD' %}/usr/local/etc/nsd{% else %}/etc/nsd{% endif %}"
+    nsd_x509_certificate_enable: yes
+
+    # XXX NEVER set this to yes in production
+    x509_certificate_debug_log: yes
     x509_certificate:
       - name: nsd_control
         state: present
         public:
-          path: "{{ nsd_conf_dir_pre }}/nsd_control.pem"
-          owner: "{% if ansible_os_family == 'OpenBSD' %}_nsd{% else %}nsd{% endif %}"
-          group: "{% if ansible_os_family == 'OpenBSD' %}_nsd{% else %}nsd{% endif %}"
+          path: "{{ nsd_conf_dir }}/nsd_control.pem"
+          owner: "{{ nsd_user }}"
+          group: "{{ nsd_group }}"
           mode: "0644"
           key: |
             -----BEGIN CERTIFICATE-----
@@ -41,9 +39,9 @@
             aIV491QzoOfbuVD5/n31wwAX/BU=
             -----END CERTIFICATE-----
         secret:
-          path: "{{ nsd_conf_dir_pre }}/nsd_control.key"
-          owner: "{% if ansible_os_family == 'OpenBSD' %}_nsd{% else %}nsd{% endif %}"
-          group: "{% if ansible_os_family == 'OpenBSD' %}_nsd{% else %}nsd{% endif %}"
+          path: "{{ nsd_conf_dir }}/nsd_control.key"
+          owner: "{{ nsd_user }}"
+          group: "{{ nsd_group }}"
           mode: "0600"
           key: |
             -----BEGIN RSA PRIVATE KEY-----
@@ -88,9 +86,9 @@
       - name: nsd_server
         state: present
         public:
-          path: "{{ nsd_conf_dir_pre }}/nsd_server.pem"
-          owner: "{% if ansible_os_family == 'OpenBSD' %}_nsd{% else %}nsd{% endif %}"
-          group: "{% if ansible_os_family == 'OpenBSD' %}_nsd{% else %}nsd{% endif %}"
+          path: "{{ nsd_conf_dir }}/nsd_server.pem"
+          owner: "{{ nsd_user }}"
+          group: "{{ nsd_group }}"
           mode: "0644"
           key: |
             -----BEGIN CERTIFICATE-----
@@ -116,9 +114,9 @@
             N49rbR5hkqy9SVm7
             -----END CERTIFICATE-----
         secret:
-          path: "{{ nsd_conf_dir_pre }}/nsd_server.key"
-          owner: "{% if ansible_os_family == 'OpenBSD' %}_nsd{% else %}nsd{% endif %}"
-          group: "{% if ansible_os_family == 'OpenBSD' %}_nsd{% else %}nsd{% endif %}"
+          path: "{{ nsd_conf_dir }}/nsd_server.key"
+          owner: "{{ nsd_user }}"
+          group: "{{ nsd_group }}"
           mode: "0600"
           key: |
             -----BEGIN RSA PRIVATE KEY-----


### PR DESCRIPTION
at the moment, this works only on CentOS but eventually should work on
all supported platforms.

see also issue #34